### PR TITLE
remove noise

### DIFF
--- a/sidecar/sidecar.py
+++ b/sidecar/sidecar.py
@@ -101,12 +101,13 @@ def watchForChanges(label, targetFolder, url, method, payload, namespace, logger
     for event in stream:
       logger.debug("Start of stream loop")
       metadata = event['object'].metadata
-      logger.info(f'Working on configmap {metadata.namespace}/{metadata.name}')
+      logger.debug(f'Working on configmap {metadata.namespace}/{metadata.name}')
       if metadata.labels is None:
         continue
-      logger.info(f'Working on configmap {metadata.namespace}/{metadata.name}')
+      logger.debug(f'Working on configmap {metadata.namespace}/{metadata.name}')
       if label in event['object'].metadata.labels.keys():
         logger.info("Configmap with label found")
+        logger.info(f'Working on configmap {metadata.namespace}/{metadata.name}')
         dataMap = event['object'].data
         if dataMap is None:
           logger.error("Configmap does not have data.")


### PR DESCRIPTION
Dear author, when using the same namespace for jenkins and other deployments, `jenkins-sc-config` logs get polluted by stuff like:

```
INFO:sidecar:Working on configmap default/cert-manager-controller
2019-05-09 10:46:10 INFO     Working on configmap default/cert-manager-controller
INFO:sidecar:Working on configmap default/cert-manager-controller
INFO:sidecar:Working on configmap default/cert-manager-controller
2019-05-09 10:46:12 INFO     Working on configmap default/cert-manager-controller
INFO:sidecar:Working on configmap default/ingress-controller-leader-gitlab-nginx
2019-05-09 10:46:13 INFO     Working on configmap default/ingress-controller-leader-gitlab-nginx
INFO:sidecar:Working on configmap default/cert-manager-controller
2019-05-09 10:46:14 INFO     Working on configmap default/cert-manager-controller
INFO:sidecar:Working on configmap default/cert-manager-controller
2019-05-09 10:46:16 INFO     Working on configmap default/cert-manager-controller
INFO:sidecar:Working on configmap default/cert-manager-controller
2019-05-09 10:46:18 INFO     Working on configmap default/cert-manager-controller
INFO:sidecar:Working on configmap default/ingress-controller-leader-gitlab-nginx
2019-05-09 10:46:20 INFO     Working on configmap default/ingress-controller-leader-gitlab-nginx
INFO:sidecar:Working on configmap default/cert-manager-controller
```

This PR completely remove this (debug?) messages. We could also consider using an env var and setting logging verbosity, if those messages are really needed.

what do you think? TIA, regards